### PR TITLE
Add Fedora Dockerfile—additions

### DIFF
--- a/3.5/Dockerfile.fedora
+++ b/3.5/Dockerfile.fedora
@@ -27,11 +27,11 @@ ENV PYTHON_VERSION=3.5 \
     PIP_NO_CACHE_DIR=off
 
 ENV SUMMARY="Platform for building and running Python $PYTHON_VERSION applications" \
-    DESCRIPTION="Python $PYTHON_VERSION available as docker container, is a base platform for \
+    DESCRIPTION="Python $PYTHON_VERSION available as docker container is a base platform for \
 building and running various Python $PYTHON_VERSION applications and frameworks. \
 Python is an easy to learn, powerful programming language. It has efficient high-level \
 data structures and a simple but effective approach to object-oriented programming. \
-Python’s elegant syntax and dynamic typing, together with its interpreted nature, \
+Python's elegant syntax and dynamic typing, together with its interpreted nature, \
 make it an ideal language for scripting and rapid application development in many areas \
 on most platforms."
 
@@ -61,7 +61,7 @@ COPY root /
 # Create a Python virtual environment for use by any application to avoid
 # potential conflicts with Python packages preinstalled in the main Python
 # installation.
-RUN virtualenv-$VERSION /opt/app-root
+RUN virtualenv-$PYTHON_VERSION /opt/app-root
 
 # In order to drop the root user, we have to make some directories world
 # writable as OpenShift default security model is to run the container under

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -66,6 +66,8 @@ for dir in ${dirs}; do
     *)
       if [ "${OS}" == "centos7" ]; then
         NAMESPACE="centos/"
+      elif [ "${OS}" == "fedora" ]; then
+        NAMESPACE="fedora/"
       else
         # we don't test rhel versions of SCL owned images
         if [[ "${SKIP_RHEL_SCL}" == "1" ]]; then
@@ -87,6 +89,8 @@ for dir in ${dirs}; do
   pushd ${dir} > /dev/null
   if [ "$OS" == "rhel7" -o "$OS" == "rhel7-candidate" ]; then
     docker_build_with_version Dockerfile.rhel7
+  elif [ "$OS" == "fedora" -o "$OS" == "fedora-candidate" ]; then
+    docker_build_with_version Dockerfile.fedora
   else
     docker_build_with_version Dockerfile
   fi

--- a/hack/common.mk
+++ b/hack/common.mk
@@ -4,6 +4,8 @@ build = hack/build.sh
 
 ifeq ($(TARGET),rhel7)
 	OS := rhel7
+else ifeq ($(TARGET),fedora)
+	OS := fedora
 else
 	OS := centos7
 endif


### PR DESCRIPTION
Related to PR #185.

Without this change the image is built as `centos/python-35-centos7`, with it as `fedora/python-35-fedora`. Though I'm not certain if there isn't more appropriate name and namespace.